### PR TITLE
fix(security): bump pnpm override floor for undici + markdown-it (TIM-29)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   underscore: '>=1.13.8'
-  markdown-it: '>=14.1.1'
+  markdown-it: '>=14.2.0'
   test-exclude>minimatch: '>=10.2.1'
   qs: '>=6.15.2'
   rollup: '>=4.59.0'
@@ -25,7 +25,7 @@ overrides:
   vitest>picomatch: 4.0.4
   mocha>diff: '>=8.0.3'
   '@textlint/linter-formatter>lodash': '>=4.18.0'
-  undici: '>=7.24.0'
+  undici: '>=8.5.0'
   fast-uri: '>=3.1.2'
   tmp: '>=0.2.6'
   esbuild: '>=0.28.1'
@@ -103,10 +103,10 @@ importers:
         version: 4.1.8(vitest@4.1.8)
       '@vscode/test-electron':
         specifier: 2.5.2
-        version: 2.5.2(supports-color@8.1.1)
+        version: 2.5.2
       '@vscode/vsce':
         specifier: 3.7.1
-        version: 3.7.1(supports-color@8.1.1)
+        version: 3.7.1
       autoprefixer:
         specifier: 10.4.27
         version: 10.4.27(postcss@8.5.15)
@@ -151,7 +151,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 8.56.0
-        version: 8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 7.3.5
         version: 7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.3)
@@ -2329,8 +2329,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
@@ -2403,8 +2403,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -3150,8 +3150,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@8.0.2:
-    resolution: {integrity: sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.1.0:
@@ -4227,12 +4227,12 @@ snapshots:
 
   '@types/vscode@1.80.0': {}
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       eslint: 10.4.1(jiti@2.6.1)
@@ -4243,7 +4243,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
@@ -4273,7 +4273,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
@@ -4320,8 +4320,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.4':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -4393,10 +4393,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
+  '@vscode/test-electron@2.5.2':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.3
@@ -4442,7 +4442,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.7.1(supports-color@8.1.1)':
+  '@vscode/vsce@3.7.1':
     dependencies:
       '@azure/identity': 4.13.1
       '@secretlint/node': 10.2.2
@@ -4460,12 +4460,12 @@ snapshots:
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
       leven: 3.1.0
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       mime: 1.6.0
       minimatch: 3.1.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2(supports-color@8.1.1)
+      secretlint: 10.2.2
       semver: 7.7.4
       tmp: 0.2.7
       typed-rest-client: 1.8.11
@@ -4778,7 +4778,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.0.2
+      undici: 8.5.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -5370,14 +5370,14 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -5642,7 +5642,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -5710,11 +5710,11 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -6195,7 +6195,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
-  secretlint@10.2.2(supports-color@8.1.1):
+  secretlint@10.2.2:
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2
@@ -6482,10 +6482,10 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.8
 
-  typescript-eslint@8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3):
+  typescript-eslint@8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@10.4.1(jiti@2.6.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.56.0(eslint@10.4.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.4.1(jiti@2.6.1)
@@ -6501,7 +6501,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@8.0.2: {}
+  undici@8.5.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ onlyBuiltDependencies:
 
 overrides:
   underscore: '>=1.13.8'
-  markdown-it: '>=14.1.1'
+  markdown-it: '>=14.2.0'
   test-exclude>minimatch: '>=10.2.1'
   qs: '>=6.15.2'
   rollup: '>=4.59.0'
@@ -30,7 +30,7 @@ overrides:
   vitest>picomatch: 4.0.4
   mocha>diff: '>=8.0.3'
   '@textlint/linter-formatter>lodash': '>=4.18.0'
-  undici: '>=7.24.0'
+  undici: '>=8.5.0'
   fast-uri: '>=3.1.2'
   tmp: '>=0.2.6'
   esbuild: '>=0.28.1'


### PR DESCRIPTION
## Summary

Closes the 9 advisories surfaced by the TIM-27 dependency audit by raising the pnpm-workspace `undici` and `markdown-it` override floors above the vulnerable version range.

The previous floors sat **inside** the vulnerable window:

```yaml
undici:      '>=7.24.0'   # resolved to 8.0.2 (vulnerable, 8.0.0 < 8.5.0)
markdown-it: '>=14.1.1'   # resolved to 14.1.1 (<=14.1.1)
```

This PR raises them to:

```yaml
undici:      '>=8.5.0'    # resolves to 8.5.0 (patched)
markdown-it: '>=14.2.0'   # resolves to 14.2.0 (patched)
```

`pnpm install --lockfile-only` then re-resolves the affected transitives without touching any direct dependency versions in `package.json`.

## Resolves

| Sev | Count | Package | Vulnerability | Path |
|---|---|---|---|---|
| High | 4 | undici 8.0.2 → 8.5.0 | TLS / WebSocket / SOCKS5 advisories | `@vscode/vsce > cheerio > undici` |
| Moderate | 3 | undici 8.0.2 → 8.5.0 | cache / cookie / cross-origin advisories | same path |
| Low | 2 | undici 8.0.2 → 8.5.0 | minor | same path |
| Moderate | 1 | markdown-it 14.1.1 → 14.2.0 | CVE-2026-48988 (smartquotes DoS) | `@vscode/vsce > markdown-it` |

Full audit: see [TIM-27](https://github.com/timoa/workflow-editor/issues/27).

## Verification

- `pnpm audit --audit-level=high` → **0 findings** (matches the existing CI gate in `.github/workflows/pull-request.yml` and `release.yml`)
- `pnpm audit --audit-level=moderate` → **0 findings**
- `pnpm audit --audit-level=low` → **0 findings**
- `[[IgnoredVulns]]` in `osv-scanner.toml` unchanged (GHSA-2g4f-4pwh-qvx6 on `ajv`, GHSA-3ppc-4f35-3m26 on `minimatch`)
- No new `pnpm outdated` drift — this is a lockfile-only install
- Lockfile diff: 70 lines (+33 / -33), confined to `undici`, `markdown-it`, the transitive `linkify-it` 5.0.0 → 5.0.1 bump, and dedup of the now-unused `supports-color@8.1.1` peer entries

## Out of scope (tracked separately)

- **`@vscode/vsce` 3.7.1 → 3.9.2 bump** — skipped from this PR. The override-floor fix already closes all 9 advisories; bundling a non-security vsce bump would muddy the audit trail and add unrelated churn. Trivial to land in a follow-up.
- **CI `--audit-level=moderate`** (TIM-27 Actionable #4) — separate PR for independent rollback.
- **`osv-scanner` CI wiring** (TIM-27 Actionable #5) — separate PR.
- **Major-bump cycle** (`@types/vscode` 1.80 → 1.125, `@types/node` 24 → 26, `vite` 7 → 8, `typescript` 5 → 6, `webpack-cli` 6 → 7, `@vitejs/plugin-react` 5 → 6, `@vscode/test-electron` 2 → 3) — TIM-27 Actionable #3, separate cycle.

## Risk

Build-time only — `@vscode/vsce` is loaded exclusively by `pnpm run package` / `pnpm run publish` and does not ship in the published `.vsix`. The vulnerable code never reaches the extension host or webview. Patched undici/markdown-it versions are drop-in from the override scope; the only behavioural change is the markdown-it smartquotes performance fix (the `typographer: true` quadratic-time issue).

Refs: TIM-29, TIM-27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependency version constraints for `markdown-it` and `undici`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->