### PR TITLE
chore(cicd): add missing Harden Runner check for React Doctor

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -181,6 +181,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
 
       - name: React Doctor
-        uses: millionco/react-doctor@547e1e4ecdb70315d81a91ec3605701d58616ee2
+        uses: millionco/react-doctor@e9ccd4fa3d5e87d9aa1c144486f2d0670a863f72 # v2.2.8
         with:
           blocking: none
           scope: changed


### PR DESCRIPTION
## Description

The GitHub Action React Doctor doesn't have a Harden Runner block. This PR fix it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update
- [ ] Refactor/code quality improvement
- [ ] Dependency update

## Checklist

### Code quality

- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`, `chore:`)
- [ ] I have not introduced `any` TypeScript types without justification
- [ ] I have not left debug code, `console.log`, or commented-out blocks

### Testing

- [ ] I have tested the changes locally by pressing `F5` in VSCode to launch the Extension Development Host
- [ ] I have run `pnpm test`, and all tests pass
- [ ] I have run `pnpm lint`, and there are no lint errors
- [ ] I have added or updated tests to cover my changes (if applicable)

### Build & compatibility

- [ ] I have run `pnpm run compile` and `pnpm run webpack` without errors
- [ ] The extension works in VSCode (and ideally Cursor/Windsurf)

### Documentation

- [ ] I have updated the `README.md` if my change adds a new feature, keyboard shortcut, or changes existing behaviour
- [ ] I have updated or added JSDoc comments for non-obvious logic (if applicable)

## Screenshots/recordings

<!-- For UI changes, add a screenshot or screen recording. Delete this section if not applicable. -->
