### PR TITLE
fix(react-hooks): clear react-hooks/refs lint errors in SourceCodeDialog

### DIFF
--- a/src/components/SourceCodeDialog.tsx
+++ b/src/components/SourceCodeDialog.tsx
@@ -31,8 +31,6 @@ export function SourceCodeDialog({
 }: SourceCodeDialogProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const onDocChangeRef = useRef<(() => void) | null>(null)
-  onDocChangeRef.current = () => setSyntaxCheckValid(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [lintErrors, setLintErrors] = useState<LintError[]>([])
   const [syntaxCheckValid, setSyntaxCheckValid] = useState<boolean | null>(null)
@@ -70,7 +68,7 @@ export function SourceCodeDialog({
         keymap.of(defaultKeymap),
         theme,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged) onDocChangeRef.current?.()
+          if (update.docChanged) setSyntaxCheckValid(null)
         }),
       ],
     })

--- a/src/webview/components/SourceCodeDialog.tsx
+++ b/src/webview/components/SourceCodeDialog.tsx
@@ -33,8 +33,6 @@ export function SourceCodeDialog({
 }: SourceCodeDialogProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const onDocChangeRef = useRef<(() => void) | null>(null)
-  onDocChangeRef.current = () => setSyntaxCheckValid(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [lintErrors, setLintErrors] = useState<LintError[]>([])
   const [syntaxCheckValid, setSyntaxCheckValid] = useState<boolean | null>(null)
@@ -84,7 +82,7 @@ export function SourceCodeDialog({
         keymap.of(defaultKeymap),
         theme,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged) onDocChangeRef.current?.()
+          if (update.docChanged) setSyntaxCheckValid(null)
         }),
       ],
     })


### PR DESCRIPTION
## Summary

Fixes the lint failures reported on the existing dependency-vulnerability PR (#163).

Both `src/components/SourceCodeDialog.tsx` and `src/webview/components/SourceCodeDialog.tsx` were assigning `onDocChangeRef.current` during render to forward `setSyntaxCheckValid(null)` into a long-lived `EditorView.updateListener` callback. `eslint-plugin-react-hooks` v7's `refs` rule correctly flags this as a render-phase side effect.

### Fix
Drop the ref indirection entirely and call `setSyntaxCheckValid(null)` directly from inside the `EditorView.updateListener` callback. React's state setters have stable identity, so a long-lived callback capturing one is safe and lint-clean.

### Behavior
Unchanged: the syntax-check indicator still resets to `null` whenever the document changes.

### Validation
- `eslint .` — clean (exit 0)
- `tsc -p tsconfig.json --noEmit` — clean
- `vitest run` — 201/201 passing

### Diff
```
src/components/SourceCodeDialog.tsx         | 4 +---
src/webview/components/SourceCodeDialog.tsx | 4 +---
2 files changed, 2 insertions(+), 6 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Syntax validation status now resets immediately when source code is edited, ensuring displayed results accurately reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->