### PR TITLE
chore(cicd): add blocked url (nodejs.org)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,6 +39,7 @@ jobs:
             github.com:443
             ingest.codecov.io:443
             keybase.io:443
+            nodejs.org:443
             o26192.ingest.us.sentry.io:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
@@ -185,7 +186,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            firewall-api.socket.dev:443
+            github.com:443
+            o4510226365743104.ingest.us.sentry.io:443
+            registry.npmjs.org:443
+            www.react.doctor:443
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Description

Add missing nodejs.org in the Harden Runner allow list

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update
- [ ] Refactor/code quality improvement
- [ ] Dependency update

## Checklist

### Code quality

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`, `chore:`)
- [ ] I have not introduced `any` TypeScript types without justification
- [ ] I have not left debug code, `console.log`, or commented-out blocks

### Testing

- [ ] I have tested the changes locally by pressing `F5` in VSCode to launch the Extension Development Host
- [ ] I have run `pnpm test`, and all tests pass
- [ ] I have run `pnpm lint`, and there are no lint errors
- [ ] I have added or updated tests to cover my changes (if applicable)

### Build & compatibility

- [ ] I have run `pnpm run compile` and `pnpm run webpack` without errors
- [ ] The extension works in VSCode (and ideally Cursor/Windsurf)

### Documentation

- [ ] I have updated the `README.md` if my change adds a new feature, keyboard shortcut, or changes existing behaviour
- [ ] I have updated or added JSDoc comments for non-obvious logic (if applicable)

## Screenshots/recordings

<!-- For UI changes, add a screenshot or screen recording. Delete this section if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI network access rules to allow required external endpoints.
  * Enabled blocked egress monitoring with an explicit allowlist for improved build security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->