### PR TITLE
chore(ci): include pnpm/nvm updates in Pull Request CI filter

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      pnpm-or-nvm: ${{ steps.filter.outputs['pnpm-or-nvm'] }}
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -36,7 +37,7 @@ jobs:
   ci:
     name: Lint, Test, Build & Security
     needs: filter
-    if: needs.filter.outputs.code == 'true' || needs.filter.outputs.pnpm-or-nvm == 'true'
+    if: needs.filter.outputs.code == 'true' || needs.filter.outputs['pnpm-or-nvm'] == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,11 +22,21 @@ jobs:
           filters: |
             code:
               - '!(.github/workflows/**)'
+            # `pnpm-or-nvm` re-enables CI for tooling-version updates that
+            # would otherwise be invisible to the `code` filter above because
+            # pnpm and nvm version pins live under `.github/workflows/**` and
+            # in dotfile/lockfile config not covered by `code`.
+            pnpm-or-nvm:
+              - '**/.nvmrc'
+              - '.github/workflows/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
 
   ci:
     name: Lint, Test, Build & Security
     needs: filter
-    if: needs.filter.outputs.code == 'true'
+    if: needs.filter.outputs.code == 'true' || needs.filter.outputs.pnpm-or-nvm == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
The dorny/paths-filter 'code' filter excluded all of `.github/workflows/**` and was the only gate on `ci`. As a result, PRs that updated only the pnpm version pin in the workflow files (e.g. Renovate's pnpm 10 -> 11 update) silently skipped the build, lint, test, and audit jobs.

Add a sibling `pnpm-or-nvm` filter that matches the files where tooling versions live (workflow files, `.nvmrc`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`), and OR it into the `ci` job's gate. `code` and the `react-doctor` review keep their existing semantics so docs-only changes still skip CI.

Closes TIM-120

## Description

<!-- Describe what this PR changes and why. Link any related issue with "Fixes #<issue-number>" or "Closes #<issue-number>". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update
- [x] Refactor/code quality improvement
- [ ] Dependency update

## Checklist

### Code quality

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`, `chore:`)
- [ ] I have not introduced `any` TypeScript types without justification
- [ ] I have not left debug code, `console.log`, or commented-out blocks

### Testing

- [ ] I have tested the changes locally by pressing `F5` in VSCode to launch the Extension Development Host
- [ ] I have run `pnpm test`, and all tests pass
- [ ] I have run `pnpm lint`, and there are no lint errors
- [ ] I have added or updated tests to cover my changes (if applicable)

### Build & compatibility

- [ ] I have run `pnpm run compile` and `pnpm run webpack` without errors
- [ ] The extension works in VSCode (and ideally Cursor/Windsurf)

### Documentation

- [ ] I have updated the `README.md` if my change adds a new feature, keyboard shortcut, or changes existing behaviour
- [ ] I have updated or added JSDoc comments for non-obvious logic (if applicable)

## Screenshots/recordings

<!-- For UI changes, add a screenshot or screen recording. Delete this section if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pull request checks to recognize changes to Node.js and pnpm configuration.
  * Corrected workflow conditions so relevant CI checks run for configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->