### PR TITLE
ci(sast): stop skipping CodeQL on release commits

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -21,7 +21,11 @@ module.exports = {
       '@semantic-release/git',
       {
         assets: ['package.json', 'CHANGELOG.md'],
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+        // Intentional: no `[skip ci]` suffix. The release commit must
+        // trigger CodeQL so SAST scoring covers it (refs TIM-122 —
+        // SAST score 24/27). Release-only changes touch CHANGELOG.md
+        // and the package.json version bump, both cheap for CodeQL.
+        message: 'chore(release): ${nextRelease.version}\n\n${nextRelease.notes}',
       },
     ],
     [


### PR DESCRIPTION
## Summary

The semantic-release commit template baked `[skip ci]` into every release commit, which suppresses **all** workflows on those commits — including `codeql-analysis.yml`. That is why the SAST score warned '24/27 commits checked'.

This change drops the `[skip ci]` suffix so the next release commit will trigger CodeQL like every other commit on `main`.

### Diff
```
.releaserc.cjs
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+        // Intentional: no `[skip ci]` suffix. The release commit must
+        // trigger CodeQL so SAST scoring covers it (refs TIM-122 —
+        // SAST score 24/27). Release-only changes touch CHANGELOG.md
+        // and the package.json version bump, both cheap for CodeQL.
+        message: 'chore(release): ${nextRelease.version}\n\n${nextRelease.notes}',
```

### Why this is safe
Release commits only change two files (per `.releaserc.cjs` assets):
- `CHANGELOG.md` — generated prose, not scanned by `javascript-typescript` query pack.
- `package.json` — version bump only, no code change.

CodeQL will still pick them up as commits; the resulting scan is cheap and the SAST score increments to 27/27 after the next release.

### Follow-up (optional, separate PR)
Consider adding a `concurrency` group to `.github/workflows/codeql-analysis.yml` to de-duplicate scans when a release commit and a feature push race onto `main`. The reason it is not in this PR: this contributor's PAT lacks `workflow` scope and cannot update workflow files.

Refs TIM-122.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release commits can now trigger CodeQL analysis, improving security scan coverage.
  * Added documentation clarifying the release and security scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->